### PR TITLE
Use "must" language instead of "undefined behavior"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The idea of representing effects as values is inspired by Haskell's IO and vario
 A task is a 2-arity function taking a success continuation as first argument and a failure continuation as second argument. It must return a canceller, must not throw and must not block the calling thread. A call to a task function starts the execution of underlying operation, eventually calling one of the two continuations with a result.
 
 ### Continuation
-A continuation is a 1-arity function taking the result of the task as argument. Its return value should be ignored, it must not throw and must not block the calling thread. A call to any of both continuations notify termination to the caller, and the behavior of subsequent calls is undefined. A continuation may be called synchronously with the task call if result is immediately available.
+A continuation is a 1-arity function taking the result of the task as argument. Its return value should be ignored, it must not throw and must not block the calling thread. Calling either continuation notifies termination to the caller. The task executor must not make a subsequent call to either continuation. A continuation may be called synchronously with the task call if result is immediately available.
 
 ### Canceller
 A canceller is a 0-arity function. Its return value should be ignored, it must not throw and must not block the calling thread. A call to this function notifies the task executor that the caller wants the operation to be terminated as soon as possible. Cancellation is a best-effort operation and it is up to the task designer to be explicit in its cancellation strategy. Calls to a canceller are expected to be idempotent, eventually becoming no-ops when execution terminates.


### PR DESCRIPTION
Say that the task executor must not make a subsequent call to a continuation, instead of saying that it's undefined behavior.